### PR TITLE
Update game.js to resource endpoint

### DIFF
--- a/src/resources/game.js
+++ b/src/resources/game.js
@@ -4,7 +4,7 @@ class Game {
     getGame(args = { pathParams: '' }) {
         // if empty object but no pathParams return error, or handle it
         const { params, pathParams: { gamePk = '' }} = args;
-        return this.request.get(`${this.apiHost}game/${gamePk}`, { params: params });
+        return this.request.get(`${this.apiHost}game/${gamePk}/feed/live`, { params: params });
     }
     
     getGameDiffPatch(args = { pathParams: '' }) {


### PR DESCRIPTION
Adjusted the getGame() function match the endpoint listed in the README. Without the /feed/live extension, one gets a 405 error from the MLB resource saying the GET method is not supported.